### PR TITLE
FIX: add post menu button only if user loggedin

### DIFF
--- a/assets/javascripts/initializers/add-discourse-jira-button.js
+++ b/assets/javascripts/initializers/add-discourse-jira-button.js
@@ -21,7 +21,7 @@ export default {
         api.includePostAttributes("jira_issue");
 
         api.addPostMenuButton("jira", (attrs) => {
-          if (currentUser && currentUser.can_create_jira_issue && !attrs.jira_issue) {
+          if (currentUser?.can_create_jira_issue && !attrs.jira_issue) {
             return {
               action: "createIssue",
               icon: "tag",


### PR DESCRIPTION
Previously, it returned error in browser console if `currentUser` object is not available.