### PR TITLE
FIX: can use old `createmeta` endpoint in cloud API versions.

### DIFF
--- a/app/models/discourse_jira/field.rb
+++ b/app/models/discourse_jira/field.rb
@@ -9,7 +9,7 @@ module DiscourseJira
 
     def self.sync!
       return unless SiteSetting.discourse_jira_enabled
-      return if ::DiscourseJira::Api.get_version! < 9
+      return unless Api.createmeta_restricted?
 
       issue_types = DiscourseJira::IssueType.order("synced_at ASC NULLS FIRST").limit(100)
       issue_types.each do |issue_type|

--- a/app/models/discourse_jira/issue_type.rb
+++ b/app/models/discourse_jira/issue_type.rb
@@ -16,7 +16,7 @@ module DiscourseJira
         fields = data[:values] || []
       end
 
-      if Api.get_version! >= 9
+      if Api.createmeta_restricted?
         fields.each { |json| sync_field!(json[:fieldId], json) }
       else
         fields.each { |key, json| sync_field!(key, json) }
@@ -46,7 +46,7 @@ module DiscourseJira
 
     def self.sync!
       return unless SiteSetting.discourse_jira_enabled
-      return if ::DiscourseJira::Api.get_version! < 9
+      return unless Api.createmeta_restricted?
 
       projects = DiscourseJira::Project.order("synced_at ASC NULLS FIRST").limit(100)
       projects.each do |project|

--- a/app/models/discourse_jira/project.rb
+++ b/app/models/discourse_jira/project.rb
@@ -34,7 +34,7 @@ module DiscourseJira
 
       projects = []
 
-      if ::DiscourseJira::Api.get_version! >= 9
+      if Api.createmeta_restricted?
         projects = Api.getJSON("project")
       else
         data = Api.getJSON("issue/createmeta?expand=projects.issuetypes.fields")

--- a/lib/discourse_jira/api.rb
+++ b/lib/discourse_jira/api.rb
@@ -16,6 +16,11 @@ module DiscourseJira
       SiteSetting.discourse_jira_api_version
     end
 
+    def self.createmeta_restricted?
+      api_version = get_version!
+      api_version >= 9 && api_version < 1000
+    end
+
     def self.make_request(endpoint)
       if endpoint.start_with?("https://")
         uri = URI(endpoint)

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe ::DiscourseJira::Api do
       )
 
       expect(described_class.get_version!).to eq(9)
+      expect(described_class.createmeta_restricted?).to be_truthy
       expect(SiteSetting.discourse_jira_api_version).to eq(9)
     end
   end


### PR DESCRIPTION
Restricted `createmeta` endpoint is not yet supported cloud API versions (> 1000).
https://dev.discourse.org/t/jira-plugin-invalidapiresponse/97859