### PR TITLE
FIX: limit visibility of jira small action moderator posts to staff users.

### DIFF
--- a/app/controllers/discourse_jira/issues_controller.rb
+++ b/app/controllers/discourse_jira/issues_controller.rb
@@ -109,7 +109,7 @@ module DiscourseJira
             topic.add_moderator_post(
               current_user,
               I18n.t("discourse_jira.small_action", title: summary, url: result[:issue_url]),
-              post_type: Post.types[:small_action],
+              post_type: Post.types[:whisper],
               action_code: "jira_issue",
             )
           end
@@ -165,7 +165,7 @@ module DiscourseJira
                 title: json[:fields][:summary],
                 url: result[:issue_url],
               ),
-              post_type: Post.types[:small_action],
+              post_type: Post.types[:whisper],
               action_code: "jira_issue",
             )
           end

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -103,6 +103,7 @@ describe DiscourseJira::IssuesController do
       expect(response.parsed_body["issue_key"]).to eq("DIS-42")
       expect(response.parsed_body["issue_url"]).to eq("https://example.com/browse/DIS-42")
       expect(post.reload.custom_fields["jira_issue_key"]).to eq("DIS-42")
+      expect(Post.last.post_type).to eq(Post.types[:whisper])
     end
 
     it "responds with proper error message" do
@@ -220,6 +221,7 @@ describe DiscourseJira::IssuesController do
       expect(response.parsed_body["issue_key"]).to eq("DIS-42")
       expect(response.parsed_body["issue_url"]).to eq("https://example.com/browse/DIS-42")
       expect(post.reload.custom_fields["jira_issue_key"]).to eq("DIS-42")
+      expect(Post.last.post_type).to eq(Post.types[:whisper])
     end
   end
 end


### PR DESCRIPTION
Previously, it was using the `Post.types[:small_action]` post type which means it is visible to everyone. Sharing this with everyone won't give any benefits. Admins may treat it as a sensitive information.