### PR TITLE
PERF: add indexes on field option table columns `field_id` and `jira_id`.

### DIFF
--- a/db/migrate/20230808054547_add_field_option_indexes.rb
+++ b/db/migrate/20230808054547_add_field_option_indexes.rb
@@ -2,12 +2,8 @@
 
 class AddFieldOptionIndexes < ActiveRecord::Migration[7.0]
   def change
-    add_index :jira_field_options,
-              :field_id,
-              name: :index_jira_field_options_on_field_id
-    add_index :jira_field_options,
-              :jira_id,
-              name: :index_jira_field_options_on_jira_id
+    add_index :jira_field_options, :field_id, name: :index_jira_field_options_on_field_id
+    add_index :jira_field_options, :jira_id, name: :index_jira_field_options_on_jira_id
     add_index :jira_field_options,
               %i[field_id jira_id],
               unique: true,

--- a/db/migrate/20230808054547_add_field_option_indexes.rb
+++ b/db/migrate/20230808054547_add_field_option_indexes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFieldOptionIndexes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :jira_field_options,
+              :field_id,
+              name: :index_jira_field_options_on_field_id
+    add_index :jira_field_options,
+              :jira_id,
+              name: :index_jira_field_options_on_jira_id
+    add_index :jira_field_options,
+              %i[field_id jira_id],
+              unique: true,
+              name: :index_jira_field_options_on_field_id_and_jira_id
+  end
+end


### PR DESCRIPTION
Querying the `field_options` table affects performance when there are lots of fields and options available.