### PR TITLE
DEV: execute the `sync_jira` job only when the Jira URL is present.

### DIFF
--- a/app/jobs/scheduled/sync_jira.rb
+++ b/app/jobs/scheduled/sync_jira.rb
@@ -6,6 +6,7 @@ module ::Jobs
 
     def execute(args)
       return unless SiteSetting.discourse_jira_enabled
+      return if SiteSetting.discourse_jira_url.blank?
 
       ::DiscourseJira::IssueType.sync!
       ::DiscourseJira::Project.sync!

--- a/spec/jobs/scheduled/sync_jira_spec.rb
+++ b/spec/jobs/scheduled/sync_jira_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Jobs::SyncJira do
+  let(:job) { described_class.new }
+  subject(:execute) { job.execute({}) }
+
+  before do
+    SiteSetting.discourse_jira_enabled = true
+    SiteSetting.discourse_jira_url = "https://jira.example.com"
+  end
+
+  it "syncs issue types and projects" do
+    ::DiscourseJira::IssueType.expects(:sync!).once
+    ::DiscourseJira::Project.expects(:sync!).once
+    execute
+  end
+
+  it "does not sync if jira URL is blank" do
+    SiteSetting.discourse_jira_url = ""
+    ::DiscourseJira::IssueType.expects(:sync!).never
+    ::DiscourseJira::Project.expects(:sync!).never
+    execute
+  end
+end


### PR DESCRIPTION
Previously, it created the logs noise with `both URI are relative` exception when the plugin is enabled but the Jira URL is not set.