### PR TITLE
DEV: cache the Jira's `createmeta` API endpoint response.

### DIFF
--- a/app/models/discourse_jira/field.rb
+++ b/app/models/discourse_jira/field.rb
@@ -6,6 +6,14 @@ module DiscourseJira
     DEFAULT_FIELDS ||= %w[summary description].freeze
 
     def self.fetch(project_id, issue_type_id)
+      Discourse
+        .cache
+        .fetch("jira-createmeta-#{project_id}-#{issue_type_id}", expires_in: 6.hours) do
+          Field.fetch_from_jira(project_id, issue_type_id)
+        end
+    end
+
+    def self.fetch_from_jira(project_id, issue_type_id)
       fields = []
 
       if Api.createmeta_restricted?


### PR DESCRIPTION
We don't need to call the API endpoint for each request while rendering the fields in issue form.