### PR TITLE
FIX: use `project_id` to create jira issues instead of project key.

### DIFF
--- a/app/controllers/discourse_jira/issues_controller.rb
+++ b/app/controllers/discourse_jira/issues_controller.rb
@@ -38,13 +38,14 @@ module DiscourseJira
     end
 
     def create
+      params.require(:project_id)
       summary = I18n.t("discourse_jira.issue_title", title: params[:title])
       issue_type = IssueType.find_by(id: params[:issue_type_id])
       raise Discourse::NotFound if issue_type.blank?
 
       fields = {
         project: {
-          key: params[:project_key],
+          key: project.key,
         },
         summary: summary,
         description: params[:description],
@@ -53,7 +54,7 @@ module DiscourseJira
         },
       }
 
-      params[:fields].each do |_, data|
+      (params[:fields] || []).each do |_, data|
         next if data.blank?
         next if data[:value].blank? && !data[:required]
 
@@ -214,6 +215,10 @@ module DiscourseJira
     end
 
     private
+
+    def project
+      @project ||= Project.find_by(id: params[:project_id])
+    end
 
     def ensure_can_create_jira_issue
       guardian.ensure_can_create_jira_issue!

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -44,6 +44,7 @@ describe DiscourseJira::IssuesController do
 
   describe "#create" do
     let(:issue_type) { Fabricate(:jira_issue_type) }
+    let(:project) { Fabricate(:jira_project) }
 
     it "requires user to be signed in" do
       post "/jira/issues.json"
@@ -64,7 +65,7 @@ describe DiscourseJira::IssuesController do
 
       stub_request(:post, "https://example.com/rest/api/2/issue").with(
         body:
-          "{\"fields\":{\"project\":{\"key\":\"DIS\"},\"summary\":\"[Discourse] \",\"description\":\"This is a bug\",\"issuetype\":{\"id\":#{issue_type.uid}},\"software\":\"value\",\"platform\":{\"id\":\"windows\"}}}",
+          "{\"fields\":{\"project\":{\"key\":\"#{project.key}\"},\"summary\":\"[Discourse] \",\"description\":\"This is a bug\",\"issuetype\":{\"id\":#{issue_type.uid}},\"software\":\"value\",\"platform\":{\"id\":\"windows\"}}}",
       ).to_return(
         status: 201,
         body: '{"id":"10041","key":"DIS-42","self":"https://example.com/rest/api/2/issue/10041"}',
@@ -80,7 +81,7 @@ describe DiscourseJira::IssuesController do
       expect do
         post "/jira/issues.json",
              params: {
-               project_key: "DIS",
+               project_id: project.id,
                description: "This is a bug",
                issue_type_id: issue_type.id,
                topic_id: post.topic_id,
@@ -118,7 +119,7 @@ describe DiscourseJira::IssuesController do
 
       post "/jira/issues.json",
            params: {
-             project_key: "DIS",
+             project_id: project.id,
              description: "This is a bug",
              issue_type_id: issue_type.id,
              topic_id: post.topic_id,


### PR DESCRIPTION
After the commit https://github.com/discourse/discourse-jira/commit/28248fb7b385da17be6b18a3fca1ce0d680071dc, Discourse front-end no longer sending the project key while creating a new Jira issue. Instead we should use local project id.