### PR TITLE
FIX: retrieve issue types from single project endpoint if not available.

### DIFF
--- a/app/models/discourse_jira/project.rb
+++ b/app/models/discourse_jira/project.rb
@@ -8,7 +8,9 @@ module DiscourseJira
     has_many :issue_types, through: :project_issue_types
 
     def sync!(data = nil)
-      data ||= Api.getJSON("project/#{self.uid}?expand=issueTypes")
+      if data.blank? || data[:issueTypes].blank?
+        data = Api.getJSON("project/#{self.uid}?expand=issueTypes")
+      end
 
       self.name = data[:name]
       self.key = data[:key]

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -16,10 +16,7 @@ RSpec.describe DiscourseJira::Project do
 
   describe ".sync!" do
     let(:issue_types) do
-      [
-        { id: "3", name: "Task", subtask: false },
-        { id: "1", name: "Bug", subtask: false }
-      ]
+      [{ id: "3", name: "Task", subtask: false }, { id: "1", name: "Bug", subtask: false }]
     end
     let(:projects) do
       [

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -15,10 +15,16 @@ RSpec.describe DiscourseJira::Project do
   end
 
   describe ".sync!" do
+    let(:issue_types) do
+      [
+        { id: "3", name: "Task", subtask: false },
+        { id: "1", name: "Bug", subtask: false }
+      ]
+    end
     let(:projects) do
       [
-        { id: 100, key: "TEST", name: "Test Project" },
-        { id: 101, key: "TEST2", name: "Test Project 2" },
+        { id: 100, key: "TEST", name: "Test Project", issueTypes: issue_types },
+        { id: 101, key: "TEST2", name: "Test Project 2", issueTypes: issue_types },
       ]
     end
 


### PR DESCRIPTION
In data center API, issue types may not be available while fetching all the projects from the endpoint `project?expand=issueTypes`. In that case, we should fetch it from the single project endpoints.