### PR TITLE
FEATURE: new site setting to close topic when a Jira issue is resolved.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -12,3 +12,4 @@ en:
     discourse_jira_password: "API key assigned to the user creating issues. A password might works, but is unsafe and the API was deprecated by Atlassian"
     discourse_jira_webhook_token: "This token must be passed in the 't' query parameter of the webhook. For example: https://example.com/jira/issues/webhook?t=supersecret"
     discourse_jira_verbose_log: "Enable verbose logging for Jira plugin"
+    discourse_jira_close_topic_on_resolve: "Close the topic when the issue has a resolution"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,3 +17,5 @@ plugins:
   discourse_jira_api_version:
     default: 0
     hidden: true
+  discourse_jira_close_topic_on_resolve:
+    default: false

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -242,4 +242,37 @@ describe DiscourseJira::IssuesController do
       expect(Post.last.post_type).to eq(Post.types[:whisper])
     end
   end
+
+  describe "#webhook" do
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:post2) { Fabricate(:post, topic: topic, post_number: 1) }
+
+    before do
+      post2.custom_fields["jira_issue_key"] = "DIS-42"
+      post2.save_custom_fields
+      SiteSetting.discourse_jira_webhook_token = "secret"
+      SiteSetting.discourse_jira_close_topic_on_resolve = true
+    end
+
+    it "closes the topic when the issue has resolution" do
+      post "/jira/issues/webhook.json",
+           params: {
+             t: "secret",
+             issue_event_type_name: "issue_generic",
+             timestamp: "1536083559131",
+             webhookEvent: "jira:issue_updated",
+             issue: {
+               id: "10041",
+               key: "DIS-42",
+               fields: {
+                 resolution: {
+                   name: "Fixed",
+                 },
+               },
+             },
+           }
+
+      expect(topic.reload.closed).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Whenever the site setting `discourse_jira_close_topic_on_resolve` is enabled and the Jira issue has any value on `resolution` field, it will close the corresponding Discourse topic.