### PR TITLE
UX: use Jira's font awesome icon for post menu in topic view.

### DIFF
--- a/assets/javascripts/initializers/add-discourse-jira-button.js
+++ b/assets/javascripts/initializers/add-discourse-jira-button.js
@@ -37,10 +37,9 @@ export default {
           if (currentUser?.can_create_jira_issue && !attrs.jira_issue) {
             return {
               action: "toggleJiraMenu",
-              icon: "tag",
-              className: "create-jira-issue",
-              title: "discourse_jira.issue",
-              label: "discourse_jira.issue",
+              icon: "fab-jira",
+              className: "jira-menu",
+              title: "discourse_jira.menu.title",
               position: "first",
             };
           }

--- a/assets/javascripts/widgets/post-jira-menu.js
+++ b/assets/javascripts/widgets/post-jira-menu.js
@@ -11,14 +11,14 @@ export function buildManageButtons(attrs, currentUser) {
     contents.push({
       icon: "plus",
       className: "popup-menu-button create-issue",
-      label: "discourse_jira.actions.create_issue",
+      label: "discourse_jira.menu.create_issue",
       action: "createIssue",
     });
 
     contents.push({
       icon: "paperclip",
       className: "popup-menu-button attach-issue",
-      label: "discourse_jira.actions.attach_issue",
+      label: "discourse_jira.menu.attach_issue",
       action: "attachIssue",
     });
   }
@@ -27,7 +27,7 @@ export function buildManageButtons(attrs, currentUser) {
 }
 
 export default createWidget("post-jira-menu", {
-  tagName: "div.post-jira-menu.post-admin-menu.popup-menu",
+  tagName: "div.post-jira-menu.popup-menu",
 
   html() {
     const contents = [];

--- a/assets/stylesheets/common/discourse-jira.scss
+++ b/assets/stylesheets/common/discourse-jira.scss
@@ -1,15 +1,15 @@
 .post-controls {
-  .create-jira-issue {
-    .d-button-label {
-      margin-left: 7px;
-    }
-  }
 
   .actions {
     position: relative;
 
-    .post-jira-menu .btn {
-      color: var(--primary);
+    .post-jira-menu {
+      position: absolute;
+      bottom: auto;
+
+      .btn {
+        color: var(--primary);
+      }
     }
   }
 }

--- a/assets/stylesheets/common/discourse-jira.scss
+++ b/assets/stylesheets/common/discourse-jira.scss
@@ -1,5 +1,4 @@
 .post-controls {
-
   .actions {
     position: relative;
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,7 +4,8 @@ en:
       issue: "Issue"
       create_issue: "Create Issue"
       attach_issue: "Attach Issue"
-      actions:
+      menu:
+        title: "Jira menu"
         create_issue: "Create new issue"
         attach_issue: "Attach existing issue"
       create_form:

--- a/plugin.rb
+++ b/plugin.rb
@@ -12,7 +12,7 @@ enabled_site_setting :discourse_jira_enabled
 
 register_asset "stylesheets/common/discourse-jira.scss"
 
-register_svg_icon "paperclip"
+%w[paperclip fab-jira].each { |icon| register_svg_icon icon }
 
 require_relative "lib/discourse_jira/api"
 require_relative "lib/discourse_jira/engine"


### PR DESCRIPTION
Also, it removes the label from the Jira post menu.

### Before

<img width="166" alt="Screenshot 2023-08-27 at 3 00 37 PM" src="https://github.com/discourse/discourse-jira/assets/9372109/e5993555-009f-4c63-905e-65c2fcf3e42b">

### After

<img width="297" alt="Screenshot 2023-08-27 at 2 55 55 PM" src="https://github.com/discourse/discourse-jira/assets/9372109/186dd781-5dee-4ef0-b422-4326e67de29f">