### PR TITLE
FEATURE: sync Jira issue comments with Discourse topic replies via webhook.

### DIFF
--- a/app/controllers/discourse_jira/issues_controller.rb
+++ b/app/controllers/discourse_jira/issues_controller.rb
@@ -106,8 +106,7 @@ module DiscourseJira
             },
           )
 
-        post.custom_fields["jira_issue_key"] = result[:issue_key]
-        post.save_custom_fields
+        post.jira_issue_key = result[:issue_key]
 
         if topic = Topic.find_by(id: params[:topic_id])
           if current_user.guardian.can_create_post_on_topic?(topic)
@@ -156,8 +155,7 @@ module DiscourseJira
             },
           )
 
-        post.custom_fields["jira_issue_key"] = result[:issue_key]
-        post.save_custom_fields
+        post.jira_issue_key = result[:issue_key]
 
         if topic = Topic.find_by(id: params[:topic_id])
           if current_user.guardian.can_create_post_on_topic?(topic)
@@ -186,6 +184,7 @@ module DiscourseJira
       log(params.inspect)
 
       if SiteSetting.discourse_jira_webhook_token.present?
+        params.require(:t)
         if !ActiveSupport::SecurityUtils.secure_compare(
              params[:t],
              SiteSetting.discourse_jira_webhook_token,
@@ -198,23 +197,43 @@ module DiscourseJira
         )
       end
 
-      issue = params[:issue]
-      post =
-        Post.joins(:_custom_fields).find_by(
-          _custom_fields: {
-            name: "jira_issue_key",
-            value: issue[:key],
-          },
-        )
-      raise Discourse::NotFound if post.blank?
+      event = params[:webhookEvent]
+      issue_event = params[:issue_event_type_name]
 
-      post.custom_fields["jira_issue"] = issue.to_json
-      post.save_custom_fields
+      if event == "jira:issue_updated"
+        issue = params[:issue]
+        post =
+          Post.joins(:_custom_fields).find_by(
+            _custom_fields: {
+              name: "jira_issue_key",
+              value: issue[:key],
+            },
+          )
+        raise Discourse::NotFound if post.blank?
 
-      if SiteSetting.discourse_jira_close_topic_on_resolve && issue[:fields][:resolution].present?
-        topic = post.topic
-        if post.post_number == 1 && topic&.open?
-          topic.update_status("closed", true, Discourse.system_user)
+        post.custom_fields["jira_issue"] = issue.to_json
+        post.save_custom_fields
+
+        if SiteSetting.discourse_jira_close_topic_on_resolve && issue[:fields][:resolution].present?
+          topic = post.topic
+          if post.post_number == 1 && topic&.open?
+            topic.update_status("closed", true, Discourse.system_user)
+          end
+        end
+
+        if SiteSetting.discourse_jira_sync_issue_comments && issue_event == "issue_commented" && post.is_first_post?
+          topic = post.topic
+          comment = params[:comment]
+
+          PostCreator.create!(
+            Discourse.system_user,
+            topic_id: topic.id,
+            raw: comment[:body],
+            skip_validations: true,
+            custom_fields: {
+              "jira_comment_id" => comment[:id],
+            },
+          )
         end
       end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,3 +13,4 @@ en:
     discourse_jira_webhook_token: "This token must be passed in the 't' query parameter of the webhook. For example: https://example.com/jira/issues/webhook?t=supersecret"
     discourse_jira_verbose_log: "Enable verbose logging for Jira plugin"
     discourse_jira_close_topic_on_resolve: "Close the topic when the issue has a resolution"
+    discourse_jira_sync_issue_comments: "Sync issue comments to Discourse topic via webhook"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,5 @@ plugins:
     hidden: true
   discourse_jira_close_topic_on_resolve:
     default: false
+  discourse_jira_sync_issue_comments:
+    default: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -36,6 +36,16 @@ after_initialize do
 
   add_to_class(:post, :has_jira_issue?) { custom_fields["jira_issue"].present? }
 
+  add_to_class(:post, :jira_issue_key=) do |key|
+    custom_fields["jira_issue_key"] = key
+    save_custom_fields
+
+    if is_first_post?
+      topic.custom_fields["jira_issue_key"] = key
+      topic.save_custom_fields
+    end
+  end
+
   add_to_serializer(:current_user, :can_create_jira_issue, false) { true }
 
   add_to_serializer(:current_user, :include_can_create_jira_issue?) { scope.can_create_jira_issue? }

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "json"
+require_relative "../spec_helper"
 
 describe DiscourseJira::IssuesController do
   let(:admin) { Fabricate(:admin) }
@@ -249,13 +251,12 @@ describe DiscourseJira::IssuesController do
     fab!(:post2) { Fabricate(:post, topic: topic, post_number: 1) }
 
     before do
-      post2.custom_fields["jira_issue_key"] = "DIS-42"
-      post2.save_custom_fields
+      post2.jira_issue_key = "DIS-42"
       SiteSetting.discourse_jira_webhook_token = "secret"
-      SiteSetting.discourse_jira_close_topic_on_resolve = true
     end
 
     it "closes the topic when the issue has resolution" do
+      SiteSetting.discourse_jira_close_topic_on_resolve = true
       post "/jira/issues/webhook.json",
            params: {
              t: "secret",
@@ -274,6 +275,30 @@ describe DiscourseJira::IssuesController do
            }
 
       expect(topic.reload.closed).to eq(true)
+    end
+
+    it "creates reply to topic when the issue is commented" do
+      SiteSetting.discourse_jira_sync_issue_comments = true
+      
+      expect {
+        post "/jira/issues/webhook.json",
+          params: {
+            t: "secret",
+            issue_event_type_name: "issue_commented",
+            timestamp: "1536083559131",
+            webhookEvent: "jira:issue_updated",
+            issue: {
+              id: "10041",
+              key: "DIS-42"
+            },
+            comment: {
+              id: "10041",
+              body: "This is a comment"
+            }
+          }
+      }.to change { topic.reload.posts.count }.by(1)
+
+      expect(topic.posts.last.raw).to eq("This is a comment")
     end
   end
 end


### PR DESCRIPTION
When a Jira issue is created in a topic's first post it will create reply posts for each Jira comment created. This feature requires webhook configuration.