### PR TITLE
FEATURE: add Discourse specific custom fields to Jira's default screen.

### DIFF
--- a/app/jobs/scheduled/sync_jira_fields.rb
+++ b/app/jobs/scheduled/sync_jira_fields.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ::Jobs
+  class SyncJira < ::Jobs::Scheduled
+    every 8.hours
+
+    def execute(args)
+      return unless SiteSetting.discourse_jira_enabled
+      return if SiteSetting.discourse_jira_url.blank?
+
+      ::DiscourseJira::Field.create_discourse_fields!
+      ::DiscourseJira::Field.sync!
+    end
+  end
+end

--- a/app/jobs/scheduled/sync_jira_fields.rb
+++ b/app/jobs/scheduled/sync_jira_fields.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ::Jobs
-  class SyncJira < ::Jobs::Scheduled
+  class SyncJiraFields < ::Jobs::Scheduled
     every 8.hours
 
     def execute(args)

--- a/app/models/discourse_jira/field.rb
+++ b/app/models/discourse_jira/field.rb
@@ -59,6 +59,7 @@ module DiscourseJira
             name: field[:name],
             required: field[:required],
             field_type: field[:schema][:type],
+            hidden: DISCOURSE_FIELDS.keys.include?(field[:name]),
             options: field[:allowedValues]&.map { |o| { id: o[:id], value: o[:value] } },
           }
         end

--- a/assets/javascripts/discourse/controllers/discourse-jira-create.js
+++ b/assets/javascripts/discourse/controllers/discourse-jira-create.js
@@ -103,11 +103,16 @@ export default Controller.extend(ModalFunctionality, {
   },
 
   @discourseComputed("fields")
+  visibleFields(fields) {
+    return fields.filter((field) => !field.hidden);
+  },
+
+  @discourseComputed("visibleFields")
   requiredFields(fields) {
     return fields.filter((field) => field.required);
   },
 
-  @discourseComputed("fields")
+  @discourseComputed("visibleFields")
   optionalFields(fields) {
     return fields.filter((field) => !field.required);
   },

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,3 +13,4 @@ en:
     discourse_jira_webhook_token: "This token must be passed in the 't' query parameter of the webhook. For example: https://example.com/jira/issues/webhook?t=supersecret"
     discourse_jira_verbose_log: "Enable verbose logging for Jira plugin"
     discourse_jira_close_topic_on_resolve: "Close the topic when the issue has a resolution"
+    discourse_jira_add_fields_to_default_screen: "Add Discourse custom fields to the default screen"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,5 @@ plugins:
     hidden: true
   discourse_jira_close_topic_on_resolve:
     default: false
+  discourse_jira_add_fields_to_default_screen:
+    default: false

--- a/db/migrate/20230825041252_add_columns_to_fields_table.rb
+++ b/db/migrate/20230825041252_add_columns_to_fields_table.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddColumnsToFieldsTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :jira_fields, :custom, :boolean, null: false, default: false
+    add_column :jira_fields, :discourse_field, :boolean, null: false, default: false
+  end
+end

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -185,6 +185,7 @@ describe DiscourseJira::IssuesController do
         [
           {
             "field_type" => "string",
+            "hidden" => false,
             "key" => "software",
             "name" => "Software",
             "options" => nil,
@@ -192,6 +193,7 @@ describe DiscourseJira::IssuesController do
           },
           {
             "field_type" => "option",
+            "hidden" => false,
             "key" => "platform",
             "name" => "Platform",
             "options" => [{ "id" => 5, "value" => "Windows" }, { "id" => 6, "value" => "Mac" }],


### PR DESCRIPTION
This PR will create Discourse-specific custom fields in Jira. It will add them to the default screen if the corresponding site setting `discourse_jira_add_fields_to_default_screen` is enabled.