### PR TITLE
DEV: drop `issue_type_id` and `required` columns which no longer needed.

### DIFF
--- a/app/models/discourse_jira/field.rb
+++ b/app/models/discourse_jira/field.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module DiscourseJira
-  class Field
+  class Field < ::ActiveRecord::Base
+    self.table_name = "jira_fields"
+
     SUPPORTED_TYPES ||= %w[string date array option].freeze
     DEFAULT_FIELDS ||= %w[summary description].freeze
 

--- a/db/post_migrate/20230907162554_drop_issue_type_id_column.rb
+++ b/db/post_migrate/20230907162554_drop_issue_type_id_column.rb
@@ -3,6 +3,7 @@
 require "migration/column_dropper"
 
 class DropIssueTypeIdColumn < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
   DROPPED_COLUMNS ||= { jira_fields: %i[issue_type_id required] }
 
   def up

--- a/db/post_migrate/20230907162554_drop_issue_type_id_column.rb
+++ b/db/post_migrate/20230907162554_drop_issue_type_id_column.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "migration/column_dropper"
+
+class DropIssueTypeIdColumn < ActiveRecord::Migration[7.0]
+  DROPPED_COLUMNS ||= { jira_fields: %i[issue_type_id required] }
+
+  def up
+    execute <<~SQL
+      TRUNCATE TABLE jira_fields CASCADE
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS index_jira_fields_on_issue_type_id_and_key
+    SQL
+
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
We're not going to track each field's relationship with issue types in Jira. So we can remove the columns `issue_type_id` and `required`.