### PR TITLE
DEV: sync projects and issue types when Jira URL changed or enabled.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -23,7 +23,7 @@ after_initialize do
   end
 
   on(:site_setting_changed) do |name|
-    Jobs.enqueue(:sync_jira) if [:discourse_jira_enabled, :discourse_jira_url].include?(name)
+    Jobs.enqueue(:sync_jira) if %i[discourse_jira_enabled discourse_jira_url].include?(name)
   end
 
   add_to_class(:guardian, :can_create_jira_issue?) do

--- a/plugin.rb
+++ b/plugin.rb
@@ -22,6 +22,10 @@ after_initialize do
     user&.staff? ? %w[jira_issue_key jira_issue] : []
   end
 
+  on(:site_setting_changed) do |name|
+    Jobs.enqueue(:sync_jira) if [:discourse_jira_enabled, :discourse_jira_url].include?(name)
+  end
+
   add_to_class(:guardian, :can_create_jira_issue?) do
     SiteSetting.discourse_jira_enabled && is_staff?
   end


### PR DESCRIPTION
Since the `SyncJira` job only recurs every 4 hours we have to trigger it manually when the site settings are updated initially.