### PR TITLE
FIX: Remove dependence on old core widget

### DIFF
--- a/assets/javascripts/widgets/post-jira-menu.js
+++ b/assets/javascripts/widgets/post-jira-menu.js
@@ -34,7 +34,7 @@ export default createWidget("post-jira-menu", {
 
     buildManageButtons(this.attrs, this.currentUser).forEach((b) => {
       b.secondaryAction = "closeJiraMenu";
-      contents.push(this.attach("post-admin-menu-button", b));
+      contents.push(this.attach("post-jira-menu-button", b));
     });
 
     return h("ul", contents);
@@ -42,5 +42,20 @@ export default createWidget("post-jira-menu", {
 
   clickOutside() {
     this.sendWidgetAction("closeJiraMenu");
+  },
+});
+
+createWidget("post-jira-menu-button", {
+  tagName: "li",
+
+  html(attrs) {
+    return this.attach("button", {
+      className: attrs.className,
+      action: attrs.action,
+      url: attrs.url,
+      icon: attrs.icon,
+      label: attrs.label,
+      secondaryAction: attrs.secondaryAction,
+    });
   },
 });


### PR DESCRIPTION
post-admin-menu-button was removed from core in https://github.com/discourse/discourse/commit/2a10ea0e3f858f243330edce5a07015df72d7f88. It was very simple, so the simplest fix is to just re-implement it here.