### PR TITLE
FIX: value of 'required' attr is string in 'fields' params.

### DIFF
--- a/app/controllers/discourse_jira/issues_controller.rb
+++ b/app/controllers/discourse_jira/issues_controller.rb
@@ -57,7 +57,7 @@ module DiscourseJira
 
       (params[:fields] || []).each do |_, data|
         next if data.blank?
-        next if data[:value].blank? && !data[:required]
+        next if data[:value].blank? && data[:required] != "true"
 
         case data[:field_type]
         when "array"

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -98,6 +98,11 @@ describe DiscourseJira::IssuesController do
                    value: "windows",
                    field_type: "option",
                  },
+                 "2": {
+                    key: "customfield_10010",
+                    field_type: "array",
+                    required: "false",
+                 },
                },
              }
       end.to change { Post.count }.by(1)

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -99,9 +99,9 @@ describe DiscourseJira::IssuesController do
                    field_type: "option",
                  },
                  "2": {
-                    key: "customfield_10010",
-                    field_type: "array",
-                    required: "false",
+                   key: "customfield_10010",
+                   field_type: "array",
+                   required: "false",
                  },
                },
              }


### PR DESCRIPTION
Previously, since we treated it as boolean it returned `true` even when the value is `"false"` string.