### PR TITLE
SECURITY: use `FinalDestination` to prevent SSRF attacks on API calls.

### DIFF
--- a/lib/discourse_jira/api.rb
+++ b/lib/discourse_jira/api.rb
@@ -47,7 +47,10 @@ module DiscourseJira
         request = yield(uri, headers)
         http.request(request)
       end
-    rescue FinalDestination::SSRFDetector::DisallowedIpError, SocketError, Timeout::Error
+    rescue FinalDestination::SSRFDetector::DisallowedIpError => e
+      Discourse.warn_exception(e, message: "SSRF detected", env: { url: uri.to_s })
+      raise InvalidURI
+    rescue SocketError, Timeout::Error
       raise InvalidURI
     end
 

--- a/lib/discourse_jira/api.rb
+++ b/lib/discourse_jira/api.rb
@@ -31,8 +31,6 @@ module DiscourseJira
         uri = URI.join(SiteSetting.discourse_jira_url, endpoint)
       end
 
-      FinalDestination::SSRFDetector.lookup_and_filter_ips(uri.hostname)
-
       FinalDestination::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
         headers = {
           "Content-Type" => "application/json",

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe ::DiscourseJira::Api do
 
   describe ".get_version!" do
     it "raises error for internal hosts" do
+      FinalDestination::Resolver.stubs(:lookup).returns(["192.168.1.1"])
+      Discourse.expects(:warn_exception).with(
+        instance_of(FinalDestination::SSRFDetector::DisallowedIpError),
+        message: "SSRF detected",
+        env: { url: "https://jira.example.com/rest/api/2/serverInfo" },
+      )
       expect {
         described_class.get_version!
       }.to raise_error(DiscourseJira::InvalidURI)

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -8,10 +8,22 @@ RSpec.describe ::DiscourseJira::Api do
     SiteSetting.discourse_jira_url = "https://jira.example.com"
     SiteSetting.discourse_jira_username = "jira"
     SiteSetting.discourse_jira_password = "password"
+    FinalDestination::SSRFDetector.allow_ip_lookups_in_test!
+  end
+
+  after do
+    FinalDestination::SSRFDetector.disallow_ip_lookups_in_test!
   end
 
   describe ".get_version!" do
+    it "raises error for internal hosts" do
+      expect {
+        described_class.get_version!
+      }.to raise_error(DiscourseJira::InvalidURI)
+    end
+
     it "returns the API version" do
+      FinalDestination::Resolver.stubs(:lookup).returns(["1.2.3.4"])
       stub_request(:get, "https://jira.example.com/rest/api/2/serverInfo").to_return(
         status: 200,
         body: {

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe ::DiscourseJira::Api do
       Discourse.expects(:warn_exception).with(
         instance_of(FinalDestination::SSRFDetector::DisallowedIpError),
         message: "SSRF detected",
-        env: { url: "https://jira.example.com/rest/api/2/serverInfo" },
+        env: {
+          url: "https://jira.example.com/rest/api/2/serverInfo",
+        },
       )
-      expect {
-        described_class.get_version!
-      }.to raise_error(DiscourseJira::InvalidURI)
+      expect { described_class.get_version! }.to raise_error(DiscourseJira::InvalidURI)
       WebMock.enable!
     end
 

--- a/spec/lib/api_spec.rb
+++ b/spec/lib/api_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ::DiscourseJira::Api do
         },
       )
       expect { described_class.get_version! }.to raise_error(DiscourseJira::InvalidURI)
+    ensure
       WebMock.enable!
     end
 

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -218,6 +218,21 @@ describe DiscourseJira::IssuesController do
       expect(response.status).to eq(404)
     end
 
+    it "requires issue key in correct format" do
+      sign_in(admin)
+      post = Fabricate(:post)
+
+      post "/jira/issues/attach.json",
+            params: {
+              issue_key: "../DIS/42",
+              topic_id: post.topic_id,
+              post_number: post.post_number,
+            }
+
+      expect(response.status).to eq(400)
+      expect(response.parsed_body["errors"][0]).to eq(I18n.t("invalid_params", message: "issue_key"))
+    end
+
     it "attach an existing Jira issue to post" do
       sign_in(admin)
       post = Fabricate(:post)

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -223,14 +223,16 @@ describe DiscourseJira::IssuesController do
       post = Fabricate(:post)
 
       post "/jira/issues/attach.json",
-            params: {
-              issue_key: "../DIS/42",
-              topic_id: post.topic_id,
-              post_number: post.post_number,
-            }
+           params: {
+             issue_key: "../DIS/42",
+             topic_id: post.topic_id,
+             post_number: post.post_number,
+           }
 
       expect(response.status).to eq(400)
-      expect(response.parsed_body["errors"][0]).to eq(I18n.t("invalid_params", message: "issue_key"))
+      expect(response.parsed_body["errors"][0]).to eq(
+        I18n.t("invalid_params", message: "issue_key"),
+      )
     end
 
     it "attach an existing Jira issue to post" do


### PR DESCRIPTION
Also, it will check the issue key value on the "attach" action and won't allow the `/` character in it.

Previously, an administrator could point the Jira server to an arbitrary location. After entering an issue key or an arbitrary path in the “Attach Issue” feature, the request failed, however, the output of the response was reflected in the error logs. This vulnerability could be used to enumerate ports on the remote host locally, as well as retrieve responses from non-public-facing services, such as the Prometheus Ruby Exporter. While the path to the issue lookup was automatically appended by the application, it was possible to use the “…/” notation to manipulate the path from the interface. Therefore, any user with the ability to add an existing issue to a POST could perform arbitrary GET requests against the Jira API, however, only the administrator could see the output in the error logs.