### PR TITLE
DEV: Prevent sync jobs from failing if API keys are wrong

### DIFF
--- a/app/models/discourse_jira/issue_type.rb
+++ b/app/models/discourse_jira/issue_type.rb
@@ -11,15 +11,16 @@ module DiscourseJira
     has_many :projects, through: :project_issue_types
 
     def self.sync!
-      Api
-        .getJSON("issuetype")
-        .each do |data|
-          next if data[:subtask]
-          find_or_initialize_by(uid: data[:id]).tap do |i|
-            i.name = data[:name]
-            i.save!
-          end
+      json_response = Api.getJSON("issuetype")
+      return if (json_response.is_a?(Hash) && json_response.has_key?(:error))
+
+      json_response.each do |data|
+        next if data[:subtask]
+        find_or_initialize_by(uid: data[:id]).tap do |i|
+          i.name = data[:name]
+          i.save!
         end
+      end
     end
   end
 end

--- a/app/models/discourse_jira/project.rb
+++ b/app/models/discourse_jira/project.rb
@@ -28,9 +28,10 @@ module DiscourseJira
     end
 
     def self.sync!
-      Api
-        .getJSON("project?expand=issueTypes")
-        .each { |data| find_or_initialize_by(uid: data[:id]).sync!(data) }
+      json_response = Api.getJSON("project?expand=issueTypes")
+      return if (json_response.is_a?(Hash) && json_response.has_key?(:error))
+
+      json_response.each { |data| find_or_initialize_by(uid: data[:id]).sync!(data) }
     end
   end
 end

--- a/spec/models/issue_type_spec.rb
+++ b/spec/models/issue_type_spec.rb
@@ -23,5 +23,11 @@ RSpec.describe DiscourseJira::IssueType do
 
       expect(described_class.pluck(:uid, :name)).to eq(issue_types.pluck(:id, :name))
     end
+
+    it "does not error out if error received from API" do
+      stub_request(:get, "#{api_url}/issuetype").to_return(status: 400)
+
+      expect { described_class.sync! }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
The `SyncJira` job now constantly fails if the credentials are wrong.
<img width="403" alt="Screenshot 2023-10-25 at 6 06 00 PM" src="https://github.com/discourse/discourse-jira/assets/1555215/59111a6e-e812-4cd1-a96b-cfe2a6867bdf">

Errors are already shown in the log and will continue to do so.
<img width="679" alt="Screenshot 2023-10-25 at 6 06 18 PM" src="https://github.com/discourse/discourse-jira/assets/1555215/f00be910-4cc5-43a3-b536-a56e836e6b51">

This PR prevents the job from failing. 