### PR TITLE
DEV: Move away from deprecated positional argument to add_to_serializer

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -115,14 +115,14 @@ after_initialize do
     Mustache.render(template, args).strip
   end
 
-  add_to_serializer(:current_user, :can_create_jira_issue, false) do
+  add_to_serializer(:current_user, :can_create_jira_issue, respect_plugin_enabled: false) do
     SiteSetting.discourse_jira_enabled &&
       user&.in_any_groups?(SiteSetting.discourse_jira_allowed_groups_map)
   end
 
   add_to_serializer(:current_user, :include_can_create_jira_issue?) { scope.can_create_jira_issue? }
 
-  add_to_serializer(:post, :jira_issue, false) { object.jira_issue }
+  add_to_serializer(:post, :jira_issue, respect_plugin_enabled: false) { object.jira_issue }
 
   add_to_serializer(:post, :include_jira_issue?) do
     scope.can_create_jira_issue? && object.custom_fields["jira_issue"].present?


### PR DESCRIPTION
### What is this change?

In April 2023 we deprecated the positional `respect_plugin_enabled` argument in favour of a keyword one. This PR updates this plugin to use the new version.