### PR TITLE
FIX: only send required field attributes in payload

### DIFF
--- a/assets/javascripts/discourse/components/modal/create.gjs
+++ b/assets/javascripts/discourse/components/modal/create.gjs
@@ -103,7 +103,7 @@ export default class Create extends Component {
   async createIssue() {
     this.loading = true;
     try {
-      const sanitizedFields = this.fields.map(field => {
+      const sanitizedFields = this.fields.map((field) => {
         return {
           required: field.required,
           value: field.value,

--- a/assets/javascripts/discourse/components/modal/create.gjs
+++ b/assets/javascripts/discourse/components/modal/create.gjs
@@ -103,6 +103,15 @@ export default class Create extends Component {
   async createIssue() {
     this.loading = true;
     try {
+      const sanitizedFields = this.fields.map(field => {
+        return {
+          required: field.required,
+          value: field.value,
+          key: field.key,
+          field_type: field.field_type,
+        };
+      });
+
       const result = await ajax("/jira/issues", {
         type: "POST",
         data: {
@@ -112,7 +121,7 @@ export default class Create extends Component {
           description: this.description,
           topic_id: this.topicId,
           post_number: this.postNumber,
-          fields: this.fields,
+          fields: sanitizedFields,
         },
       });
 

--- a/test/javascripts/acceptance/jira-post-menu-test.js
+++ b/test/javascripts/acceptance/jira-post-menu-test.js
@@ -253,14 +253,10 @@ acceptance("Jira - post menu", function (needs) {
           }
           return arr;
         }, []);
-      return [
-        200,
-        { "Content-Type": "application/json" },
-        JSON.stringify({
-          issue_key: "TEST-123",
-          issue_url: "https://jira.example.com/browse/TEST-123",
-        }),
-      ];
+      return response({
+        issue_key: "TEST-123",
+        issue_url: "https://jira.example.com/browse/TEST-123",
+      });
     });
   });
 
@@ -291,7 +287,11 @@ acceptance("Jira - post menu", function (needs) {
       )
     );
 
-    assert.ok(capturedFields, "The fields payload was captured");
+    assert.strictEqual(
+      typeof capturedFields,
+      "object",
+      "The fields payload was captured"
+    );
 
     capturedFields.forEach((field) => {
       assert.deepEqual(

--- a/test/javascripts/acceptance/jira-post-menu-test.js
+++ b/test/javascripts/acceptance/jira-post-menu-test.js
@@ -4,6 +4,8 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Jira - post menu", function (needs) {
+  let capturedFields = null;
+
   needs.user({ can_create_jira_issue: true });
 
   const admin_group_id = 1;
@@ -236,15 +238,31 @@ acceptance("Jira - post menu", function (needs) {
       })
     );
 
-    server.post("/jira/issues", () =>
-      response({
-        issue_key: "TEST-123",
-        issue_url: "https://jira.example.com/browse/TEST-123",
-      })
-    );
+    server.post("/jira/issues", request => {
+      const payload = Object.fromEntries(new URLSearchParams(request.requestBody));
+      capturedFields = Object.keys(payload)
+        .filter(k => k.startsWith("fields"))
+        .reduce((arr, k) => {
+          const match = k.match(/^fields\[(\d+)\]\[(\w+)\]$/);
+          if (match) {
+            const idx = parseInt(match[1], 10);
+            arr[idx] = arr[idx] || {};
+            arr[idx][match[2]] = payload[k];
+          }
+          return arr;
+        }, []);
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        JSON.stringify({
+          issue_key: "TEST-123",
+          issue_url: "https://jira.example.com/browse/TEST-123",
+        }),
+      ];
+    });
   });
 
-  test("displays custom fields in create issue form", async function (assert) {
+  test("displays custom fields in create issue form and sends only allowed field keys", async function (assert) {
     const projectSelector = selectKit(".field-item.project .select-kit");
     const issueTypeSelector = selectKit(".field-item.issue-type .select-kit");
 
@@ -270,5 +288,18 @@ acceptance("Jira - post menu", function (needs) {
         `<p><a href="https://jira.example.com/browse/TEST-123">TEST-123</a></p>`
       )
     );
+
+    assert.ok(
+      capturedFields,
+      "The fields payload was captured"
+    );
+
+    capturedFields.forEach(field => {
+      assert.deepEqual(
+        Object.keys(field).sort(),
+        ["field_type", "key", "required", "value"].sort(),
+        "Only the allowed keys are sent for each field"
+      );
+    });
   });
 });

--- a/test/javascripts/acceptance/jira-post-menu-test.js
+++ b/test/javascripts/acceptance/jira-post-menu-test.js
@@ -238,10 +238,12 @@ acceptance("Jira - post menu", function (needs) {
       })
     );
 
-    server.post("/jira/issues", request => {
-      const payload = Object.fromEntries(new URLSearchParams(request.requestBody));
+    server.post("/jira/issues", (request) => {
+      const payload = Object.fromEntries(
+        new URLSearchParams(request.requestBody)
+      );
       capturedFields = Object.keys(payload)
-        .filter(k => k.startsWith("fields"))
+        .filter((k) => k.startsWith("fields"))
         .reduce((arr, k) => {
           const match = k.match(/^fields\[(\d+)\]\[(\w+)\]$/);
           if (match) {
@@ -289,12 +291,9 @@ acceptance("Jira - post menu", function (needs) {
       )
     );
 
-    assert.ok(
-      capturedFields,
-      "The fields payload was captured"
-    );
+    assert.ok(capturedFields, "The fields payload was captured");
 
-    capturedFields.forEach(field => {
+    capturedFields.forEach((field) => {
       assert.deepEqual(
         Object.keys(field).sort(),
         ["field_type", "key", "required", "value"].sort(),


### PR DESCRIPTION
Currently we're sending over the entire field object in payload including all the dropdown options which is making the payload huge and in some cases failing with 400 error.

This commits ensures we only send the required details in payload and nothing extra.