### PR TITLE
DEV: Replace `findBy` with `find` in Jira plugin components

### DIFF
--- a/assets/javascripts/discourse/components/modal/create.gjs
+++ b/assets/javascripts/discourse/components/modal/create.gjs
@@ -34,7 +34,7 @@ export default class Create extends Component {
   }
 
   get issueTypes() {
-    const project = this.projects.findBy("id", this.projectId);
+    const project = this.projects.find((item) => item.id === this.projectId);
     return project ? project.issue_types : [];
   }
 

--- a/assets/javascripts/discourse/connectors/category-custom-settings/jira-settings.gjs
+++ b/assets/javascripts/discourse/connectors/category-custom-settings/jira-settings.gjs
@@ -29,7 +29,7 @@ export default class JiraSettings extends Component {
   }
 
   get issueTypes() {
-    const project = this.projects.findBy("id", this.projectId);
+    const project = this.projects.find((item) => item.id === this.projectId);
     return project ? project.issue_types : [];
   }
 


### PR DESCRIPTION
Update `jira-settings` and `create` modal components to replace the use of `findBy` with `find` for consistency and better clarity. This change ensures that the lookup implementation is explicit and aligns with modern JavaScript syntax.