### PR TITLE
DEV: Fix specs to work with enable_simplified_category_creation

### DIFF
--- a/spec/system/custom_category_settings_spec.rb
+++ b/spec/system/custom_category_settings_spec.rb
@@ -3,13 +3,18 @@
 RSpec.describe "Jira custom category settings'" do
   fab!(:current_user, :admin)
 
+  let(:category_page) { PageObjects::Pages::Category.new }
+
   before do
     SiteSetting.discourse_jira_enabled = true
+    SiteSetting.enable_simplified_category_creation = true
     sign_in(current_user)
   end
 
   it "renders successfully on the category settings section" do
     visit("/new-category")
+
+    category_page.toggle_advanced_settings
     find(".edit-category-settings").click
 
     expect(page).to have_css(


### PR DESCRIPTION
See discourse/discourse#39212, we
are moving this to stable which means it will be enabled by
default everywhere soon
