### PR TITLE
DEV: Update category type spec

### DIFF
--- a/spec/system/custom_category_settings_spec.rb
+++ b/spec/system/custom_category_settings_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe "Jira custom category settings'" do
   it "renders successfully on the category settings section" do
     visit("/new-category")
 
+    # When more than one category type is available, the user is shown a card
+    # picker; with only one type the picker is skipped. Click the discussion
+    # card if it's rendered, otherwise proceed straight to the form.
+    card = page.first(".category-type-cards__card.--category-type-discussion", minimum: 0)
+    card&.click
+
+    expect(page).to have_content(I18n.t("js.category.create_with_type", typeName: "discussion"))
     category_page.toggle_advanced_settings
     find(".edit-category-settings").click
 


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/39901 will
change core so there can be multiple category types, meaning
/new-category won't auto-redirect. Fix the spec so it detects
if there is a card to choose and if so select it first
