### PR TITLE
FIX: Raise 403 when token is not configured

### DIFF
--- a/app/controllers/discourse_jira/issues_controller.rb
+++ b/app/controllers/discourse_jira/issues_controller.rb
@@ -148,18 +148,19 @@ module DiscourseJira
     def webhook
       log(params.inspect)
 
-      if SiteSetting.discourse_jira_webhook_token.present?
-        params.require(:t)
-        if !ActiveSupport::SecurityUtils.secure_compare(
-             params[:t],
-             SiteSetting.discourse_jira_webhook_token,
-           )
-          raise Discourse::InvalidAccess
-        end
-      else
+      if SiteSetting.discourse_jira_webhook_token.blank?
         Rails.logger.warn(
           "discourse_jira_webhook_token is empty. Set a token to ensure malicious requests are not handled.",
         )
+        raise Discourse::InvalidAccess
+      end
+
+      params.require(:t)
+      if !ActiveSupport::SecurityUtils.secure_compare(
+           params[:t],
+           SiteSetting.discourse_jira_webhook_token,
+         )
+        raise Discourse::InvalidAccess
       end
 
       event = params[:webhookEvent]

--- a/app/controllers/discourse_jira/issues_controller.rb
+++ b/app/controllers/discourse_jira/issues_controller.rb
@@ -148,18 +148,15 @@ module DiscourseJira
     def webhook
       log(params.inspect)
 
-      if SiteSetting.discourse_jira_webhook_token.blank?
+      token = SiteSetting.discourse_jira_webhook_token
+      if token.blank?
         Rails.logger.warn(
           "discourse_jira_webhook_token is empty. Set a token to ensure malicious requests are not handled.",
         )
         raise Discourse::InvalidAccess
       end
-
       params.require(:t)
-      if !ActiveSupport::SecurityUtils.secure_compare(
-           params[:t],
-           SiteSetting.discourse_jira_webhook_token,
-         )
+      if !ActiveSupport::SecurityUtils.secure_compare(params[:t], token)
         raise Discourse::InvalidAccess
       end
 

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -376,6 +376,24 @@ describe DiscourseJira::IssuesController do
       SiteSetting.discourse_jira_webhook_token = "secret"
     end
 
+    it "rejects the webhook when the token setting is blank" do
+      SiteSetting.discourse_jira_webhook_token = ""
+      SiteSetting.discourse_jira_close_topic_on_resolve = true
+
+      post "/jira/issues/webhook.json",
+           params: {
+             issue_event_type_name: "issue_generic",
+             timestamp: "1536083559131",
+             webhookEvent: "jira:issue_updated",
+             issue: issue_param,
+           }
+
+      expect(response.status).to eq(403)
+      expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+      expect(topic.reload.closed).to eq(false)
+      expect(post2.reload.custom_fields["jira_issue"]).to be_blank
+    end
+
     it "closes the topic when the issue has resolution" do
       SiteSetting.discourse_jira_close_topic_on_resolve = true
       post "/jira/issues/webhook.json",


### PR DESCRIPTION
Having the plugin enabled with no token configured is not a supported configuration. Best to reject the webhook rather than relying on a warning log.