### PR TITLE
FIX: Restrict jira associations to visible posts/topics

### DIFF
--- a/app/controllers/discourse_jira/issues_controller.rb
+++ b/app/controllers/discourse_jira/issues_controller.rb
@@ -73,9 +73,6 @@ module DiscourseJira
         info:
           "creating Jira issue for topic #{params[:topic_id]} and post_number #{params[:post_number]}",
       ) do
-        post = Post.find_by(topic_id: params[:topic_id], post_number: params[:post_number])
-        raise Discourse::NotFound if post.blank?
-
         begin
           result = IssueCreator.create(post, current_user, fields)
         rescue InvalidApiResponse => e
@@ -216,9 +213,11 @@ module DiscourseJira
     end
 
     def ensure_can_add_jira_issue_to_post
-      if post.blank?
-        raise Discourse::NotFound
-      elsif post.has_jira_issue?
+      raise Discourse::NotFound if post.blank?
+
+      guardian.ensure_can_see!(post)
+
+      if post.has_jira_issue?
         log "Post #{post.id} already has a Jira issue"
         raise Discourse::InvalidAccess
       end

--- a/spec/requests/issues_controller_spec.rb
+++ b/spec/requests/issues_controller_spec.rb
@@ -148,6 +148,47 @@ describe DiscourseJira::IssuesController do
       )
     end
 
+    it "does not create a Jira issue for a post the user cannot see" do
+      jira_group = Fabricate(:group)
+      hidden_group = Fabricate(:group)
+      SiteSetting.discourse_jira_allowed_groups = "#{Group::AUTO_GROUPS[:admins]}|#{jira_group.id}"
+      jira_group.add(user)
+      sign_in(user)
+
+      private_category = Fabricate(:private_category, group: hidden_group)
+      hidden_post = Fabricate(:post, topic: Fabricate(:topic, category: private_category))
+
+      stub_request(:post, "https://example.com/rest/api/2/issue").to_return(
+        status: 201,
+        body: '{"id":"10041","key":"DIS-42","self":"https://example.com/rest/api/2/issue/10041"}',
+        headers: {
+        },
+      )
+      stub_request(:get, "https://example.com/rest/api/2/issue/10041").to_return(
+        status: 200,
+        body: issue_response,
+      )
+      stub_request(:post, "https://example.com/rest/api/2/issue/DIS-42/remotelink").to_return(
+        status: 201,
+        body: { id: "1", self: "https://example.com/rest/api/2/issue/DIS-42/remotelink/1" }.to_json,
+      )
+
+      expect do
+        post "/jira/issues.json",
+             params: {
+               project_id: project.id,
+               description: "This is a bug",
+               issue_type_id: issue_type.id,
+               topic_id: hidden_post.topic_id,
+               post_number: hidden_post.post_number,
+               fields: [],
+             }
+      end.not_to change { hidden_post.reload.custom_fields["jira_issue_key"] }
+
+      expect(response.status).to eq(403)
+      expect(response.parsed_body["errors"]).to be_present
+    end
+
     describe "group access" do
       let(:group) { Fabricate(:group) }
 
@@ -349,6 +390,38 @@ describe DiscourseJira::IssuesController do
       expect(response.parsed_body["issue_url"]).to eq("https://example.com/browse/DIS-42")
       expect(post.reload.custom_fields["jira_issue_key"]).to eq("DIS-42")
       expect(Post.last.post_type).to eq(Post.types[:whisper])
+    end
+
+    it "does not attach a Jira issue to a post the user cannot see" do
+      jira_group = Fabricate(:group)
+      hidden_group = Fabricate(:group)
+      SiteSetting.discourse_jira_allowed_groups = "#{Group::AUTO_GROUPS[:admins]}|#{jira_group.id}"
+      jira_group.add(user)
+      sign_in(user)
+
+      private_category = Fabricate(:private_category, group: hidden_group)
+      hidden_post = Fabricate(:post, topic: Fabricate(:topic, category: private_category))
+
+      stub_request(:get, "https://example.com/rest/api/2/issue/10041").to_return(
+        status: 200,
+        body: issue_response,
+      )
+      stub_request(:get, "https://example.com/rest/api/2/issue/DIS-42").to_return(
+        status: 200,
+        body: issue_response,
+      )
+
+      expect do
+        post "/jira/issues/attach.json",
+             params: {
+               issue_key: "DIS-42",
+               topic_id: hidden_post.topic_id,
+               post_number: hidden_post.post_number,
+             }
+      end.not_to change { hidden_post.reload.custom_fields["jira_issue_key"] }
+
+      expect(response.status).to eq(403)
+      expect(response.parsed_body["errors"]).to be_present
     end
   end
 


### PR DESCRIPTION
The endpoints are only available to specific trusted groups, so this isn't a big deal. But it makes sense to align the access levels with the posts being targetted.