### PR TITLE
SECURITY: Jira post history leaks hidden and whisper posts to unauthorized users

### DIFF
--- a/app/controllers/discourse_jira/posts_controller.rb
+++ b/app/controllers/discourse_jira/posts_controller.rb
@@ -12,7 +12,7 @@ module DiscourseJira
       raise Discourse::NotFound if !topic
       guardian.ensure_can_see!(topic)
 
-      result = topic.formatted_post_history(params[:post_number].to_i)
+      result = topic.formatted_post_history(params[:post_number].to_i, guardian)
 
       render json: { formatted_post_history: result }
     end

--- a/app/services/discourse_jira/issue_creator.rb
+++ b/app/services/discourse_jira/issue_creator.rb
@@ -96,7 +96,7 @@ module DiscourseJira
           key: project.key,
         },
         summary: summary,
-        description: topic.formatted_post_history(post.post_number),
+        description: topic.formatted_post_history(post.post_number, user.guardian),
         issuetype: {
           id: issue_type.uid,
         },

--- a/plugin.rb
+++ b/plugin.rb
@@ -90,9 +90,10 @@ after_initialize do
     end
   end
 
-  add_to_class(:topic, :formatted_post_history) do |post_number|
+  add_to_class(:topic, :formatted_post_history) do |post_number, guardian = nil|
     last_post_number = post_number.clamp(1, highest_post_number)
     posts = ordered_posts.where("post_number <= ?", last_post_number)
+    posts = posts.select { |post| guardian.can_see_post?(post) } if guardian
 
     args = {}
     args[:topic] = self

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -2,6 +2,9 @@
 
 describe DiscourseJira::PostsController do
   fab!(:admin)
+  fab!(:jira_allowed_group, :group)
+  fab!(:jira_allowed_user) { Fabricate(:user, groups: [jira_allowed_group]) }
+  fab!(:other_user, :user)
   fab!(:topic)
   fab!(:first_post) { Fabricate(:post, topic: topic, raw: "first post") }
   fab!(:second_post) { Fabricate(:post, topic: topic, post_number: 2, raw: "second post") }
@@ -30,6 +33,32 @@ describe DiscourseJira::PostsController do
       expect(response.parsed_body["formatted_post_history"]).to include("third post")
       expect(response.parsed_body["formatted_post_history"]).not_to include("fourth post")
       expect(response.parsed_body["formatted_post_history"]).to include(topic.url)
+    end
+
+    it "omits hidden and whisper posts for Jira-allowed users who cannot see them" do
+      SiteSetting.discourse_jira_allowed_groups =
+        "#{Group::AUTO_GROUPS[:admins]}|#{jira_allowed_group.id}"
+      sign_in(jira_allowed_user)
+
+      hidden_post = Fabricate(:post, topic: topic, post_number: 5, raw: "hidden post", hidden: true)
+      whisper_post =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 6,
+          raw: "whisper post",
+          post_type: Post.types[:whisper],
+          user: other_user,
+        )
+      Topic.next_post_number(topic.id)
+
+      put "/jira/posts.json", params: { topic_id: topic.id, post_number: whisper_post.post_number }
+
+      expect(response.status).to eq(200)
+      post_history = response.parsed_body["formatted_post_history"]
+      expect(post_history).to include(first_post.raw)
+      expect(post_history).not_to include(hidden_post.raw)
+      expect(post_history).not_to include(whisper_post.raw)
     end
 
     it "excludes deleted posts" do

--- a/spec/services/issue_creator_spec.rb
+++ b/spec/services/issue_creator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ::DiscourseJira::IssueCreator do
             key: "DIS",
           },
           summary: I18n.t("discourse_jira.issue_title", title: topic.title),
-          description: topic.formatted_post_history(post.post_number),
+          description: topic.formatted_post_history(post.post_number, admin.guardian),
           issuetype: {
             id: 2001,
           },


### PR DESCRIPTION
## Summary

The authenticated `PUT /jira/posts.json` endpoint and the automated Jira issue creator both rendered every nondeleted prior post without per-post visibility checks. Nonstaff members of a Jira-allowed group could receive hidden-post and whisper excerpts from topics they could otherwise view. The fix passes a Guardian object to `Topic#formatted_post_history` and filters the returned history to include only posts the acting user is permitted to see. Staff and system users retain their existing higher-privilege view.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1526

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>